### PR TITLE
InputGroup DebounceDelay via shared input.js (Option A alternative to #201)

### DIFF
--- a/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/InputGroupDemo.cs
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/InputGroupDemo.cs
@@ -119,6 +119,38 @@ namespace NeoUI.Demo.Shared.Pages.Components
                 </InputGroup>
                 """;
 
+        private const string _twoWayBindingCode = """
+                <Label>Search</Label>
+                <InputGroup>
+                    <InputGroupAddon Align="InputGroupAlign.InlineStart">
+                        <LucideIcon Name="search" Size="16" />
+                    </InputGroupAddon>
+                    <InputGroupInput Placeholder="Search..." @bind-Value="_inputGroupText" />
+                </InputGroup>
+
+                <span>Search: @_inputGroupText</span>
+
+                @code {
+                    private string _inputGroupText = "";
+                }
+                """;
+
+        private const string _debounceCode = """
+                <Label>Search</Label>
+                <InputGroup>
+                    <InputGroupAddon Align="InputGroupAlign.InlineStart">
+                        <LucideIcon Name="search" Size="16" />
+                    </InputGroupAddon>
+                    <InputGroupInput Placeholder="Search..." @bind-Value="_debouncedInputGroupText" DebounceDelay="500" />
+                </InputGroup>
+
+                <span>Text: @_debouncedInputGroupText</span>
+
+                @code {
+                    private string _debouncedInputGroupText = "";
+                }
+                """;
+
         private const string _dropdownCode = """
                 <DropdownMenu>
                     <InputGroup>

--- a/demo/NeoUI.Demo.Shared/Pages/Components/InputGroupDemo.razor
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/InputGroupDemo.razor
@@ -244,6 +244,40 @@
         </DemoBlock>
     </DemoSection>
 
+    <DemoSection Title="Two-Way Binding"
+                 Description="Two-way data binding: bind to a C# property with the bind-Value syntax.">
+        <DemoBlock Code="@_twoWayBindingCode">
+            <div class="space-y-2 max-w-sm">
+                <Label>Search</Label>
+                <InputGroup>
+                    <InputGroupAddon Align="InputGroupAlign.InlineStart">
+                        <LucideIcon Name="search" Size="16" />
+                    </InputGroupAddon>
+                    <InputGroupInput Placeholder="Search..." @bind-Value="_inputGroupText" />
+                </InputGroup>
+
+                <span>Search: @_inputGroupText</span>
+            </div>
+        </DemoBlock>
+    </DemoSection>
+
+    <DemoSection Title="Debounce"
+                 Description="Debounce the input value changes to prevent rapid firing. Handled in JS, so intermediate keystrokes never round-trip.">
+        <DemoBlock Code="@_debounceCode">
+            <div class="space-y-2 max-w-sm">
+                <Label>Search</Label>
+                <InputGroup>
+                    <InputGroupAddon Align="InputGroupAlign.InlineStart">
+                        <LucideIcon Name="search" Size="16" />
+                    </InputGroupAddon>
+                    <InputGroupInput Placeholder="Search..." @bind-Value="_debouncedInputGroupText" DebounceDelay="500" />
+                </InputGroup>
+
+                <span>Text: @_debouncedInputGroupText</span>
+            </div>
+        </DemoBlock>
+    </DemoSection>
+
     <DemoSection Title="Dropdown Menu"
                  Description="Integrate dropdown menus with input fields for context actions.">
         <DemoBlock Code="@_dropdownCode">
@@ -311,6 +345,9 @@
 
 @code {
     private InputGroupInput? _inputRef;
+
+    private string _inputGroupText = "";
+    private string _debouncedInputGroupText = "";
 
     private async Task OnClick()
     {

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor
@@ -1,8 +1,10 @@
 @namespace NeoUI.Blazor
 
+@* Input/change events are wired through the shared input.js module (see OnAfterRenderAsync)
+   so debouncing runs in the browser without a per-keystroke round-trip. *@
 <input
     @ref="_inputRef"
-    id="@Id"
+    id="@EffectiveId"
     type="@HtmlType"
     data-slot="input-group-control"
     class="@CssClass"
@@ -13,6 +15,4 @@
     aria-label="@AriaLabel"
     aria-describedby="@AriaDescribedBy"
     aria-invalid="@(AriaInvalid?.ToString().ToLower())"
-    @oninput="HandleInput"
-    @onchange="HandleChange"
     @attributes="AdditionalAttributes" />

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor.cs
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor.cs
@@ -285,9 +285,15 @@ public partial class InputGroupInput : ComponentBase, IAsyncDisposable
 
         try
         {
-            if (_jsInitialized && _inputModule is not null)
+            if (_inputModule is not null)
             {
-                await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                // Dispose the module even if initializeInput threw after a successful import.
+                // Only tear down JS-side state when initialization actually completed.
+                if (_jsInitialized)
+                {
+                    await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                }
+
                 await _inputModule.DisposeAsync();
             }
         }

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor.cs
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupInput.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace NeoUI.Blazor;
 
@@ -19,6 +20,7 @@ namespace NeoUI.Blazor;
 /// - Flexible width to fill available space
 /// - Full parameter compatibility with standard Input
 /// - Automatic marking for parent detection (data-slot attribute)
+/// - Optional input debouncing via <see cref="DebounceDelay"/> (handled in JS, no per-keystroke round-trip)
 /// </para>
 /// </remarks>
 /// <example>
@@ -28,9 +30,32 @@ namespace NeoUI.Blazor;
 /// &lt;/InputGroup&gt;
 /// </code>
 /// </example>
-public partial class InputGroupInput : ComponentBase
+public partial class InputGroupInput : ComponentBase, IAsyncDisposable
 {
     private ElementReference _inputRef;
+
+    /// <summary>
+    /// Reference to the shared input JavaScript module.
+    /// </summary>
+    private IJSObjectReference? _inputModule;
+
+    /// <summary>
+    /// DotNet object reference for JavaScript callbacks.
+    /// </summary>
+    private DotNetObjectReference<InputGroupInput>? _dotNetRef;
+
+    /// <summary>
+    /// Tracks whether the JavaScript module has been initialized.
+    /// </summary>
+    private bool _jsInitialized;
+
+    /// <summary>
+    /// Auto-generated ID used when the user does not provide one, so JS can reference the element.
+    /// </summary>
+    private string? _generatedId;
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
 
     /// <summary>
     /// Gets or sets the type of input.
@@ -81,6 +106,31 @@ public partial class InputGroupInput : ComponentBase
     public string? Id { get; set; }
 
     /// <summary>
+    /// Gets or sets when the input should update its bound value.
+    /// </summary>
+    /// <remarks>
+    /// - Input: Updates value on every input event (keystroke). Required for <see cref="DebounceDelay"/> to apply.
+    /// - Change: Updates value only when the input loses focus.
+    /// Defaults to <see cref="InputUpdateMode.Input"/> to preserve InputGroupInput's historical
+    /// update-on-keystroke behavior (this differs from the standalone Input default of Change).
+    /// </remarks>
+    [Parameter]
+    public InputUpdateMode UpdateOn { get; set; } = InputUpdateMode.Input;
+
+    /// <summary>
+    /// Gets or sets the debounce delay in milliseconds before triggering value change notifications.
+    /// Only applies when <see cref="UpdateOn"/> is <see cref="InputUpdateMode.Input"/>. Set to 0 for immediate updates.
+    /// Default: 0 (no debounce)
+    /// </summary>
+    /// <remarks>
+    /// Debouncing is handled inside the shared input JavaScript module, so intermediate keystrokes
+    /// do not round-trip to the server (Blazor Server) or spin the renderer (WebAssembly). Only the
+    /// final, debounced value is dispatched to <see cref="ValueChanged"/>.
+    /// </remarks>
+    [Parameter]
+    public int DebounceDelay { get; set; } = 0;
+
+    /// <summary>
     /// Gets or sets the ARIA label.
     /// </summary>
     [Parameter]
@@ -110,6 +160,22 @@ public partial class InputGroupInput : ComponentBase
     /// </summary>
     [Parameter]
     public Action<ElementReference>? OnInputRef { get; set; }
+
+    /// <summary>
+    /// Gets the effective ID, generating a unique one when none is provided so JS can always
+    /// reference the element.
+    /// </summary>
+    private string EffectiveId
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(Id))
+                return Id;
+
+            _generatedId ??= "input-group-input-" + Guid.NewGuid().ToString("N")[..6];
+            return _generatedId;
+        }
+    }
 
     /// <summary>
     /// Gets the computed CSS classes for the input element.
@@ -152,40 +218,86 @@ public partial class InputGroupInput : ComponentBase
     };
 
     /// <summary>
-    /// Handles the input event (fired on every keystroke).
+    /// Sets up input event handling (UpdateOn mode + debounce) through the shared input JS module.
     /// </summary>
-    private async Task HandleInput(ChangeEventArgs args)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var newValue = args.Value?.ToString();
-        Value = newValue;
+        if (!firstRender)
+            return;
+
+        try
+        {
+            _inputModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/NeoUI.Blazor/js/input.js");
+
+            _dotNetRef = DotNetObjectReference.Create(this);
+
+            // Initialize input event handling with UpdateOn mode and debounce.
+            // The JS module owns the debounce timer, so intermediate keystrokes never
+            // cross the circuit — only the final value invokes OnInputChanged.
+            await _inputModule.InvokeVoidAsync(
+                "initializeInput",
+                EffectiveId,
+                UpdateOn.ToString().ToLower(),
+                DebounceDelay,
+                _dotNetRef
+            );
+
+            _jsInitialized = true;
+        }
+        catch (Exception ex) when (ex is JSException or JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // JS module not available (e.g. circuit disconnect); the element still renders,
+            // value simply won't be wired through JS event handling.
+        }
+
+        OnInputRef?.Invoke(_inputRef);
+    }
+
+    /// <summary>
+    /// Called from JavaScript when the input value changes, based on UpdateOn mode and debounce settings.
+    /// </summary>
+    /// <param name="value">The new input value.</param>
+    [JSInvokable]
+    public async Task OnInputChanged(string? value)
+    {
+        Value = value;
 
         if (ValueChanged.HasDelegate)
         {
-            await ValueChanged.InvokeAsync(newValue);
+            await ValueChanged.InvokeAsync(value);
         }
-    }
 
-    /// <summary>
-    /// Handles the change event (fired when input loses focus).
-    /// </summary>
-    private async Task HandleChange(ChangeEventArgs args)
-    {
-        await Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Invokes the OnInputRef callback after first render.
-    /// </summary>
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender && OnInputRef != null)
-        {
-            OnInputRef.Invoke(_inputRef);
-        }
+        // Deliberately no StateHasChanged() here to avoid re-rendering (and cursor jumps) during typing.
     }
 
     /// <summary>
     /// Moves keyboard focus to the input element.
     /// </summary>
     public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
+    /// <summary>
+    /// Disposes the JavaScript module, event handlers, and object references.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        try
+        {
+            if (_jsInitialized && _inputModule is not null)
+            {
+                await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                await _inputModule.DisposeAsync();
+            }
+        }
+        catch (Exception ex) when (ex is JSException or JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // JS runtime already gone; nothing to clean up.
+        }
+
+        _inputModule = null;
+        _dotNetRef?.Dispose();
+        _dotNetRef = null;
+    }
 }

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor
@@ -1,7 +1,9 @@
 @namespace NeoUI.Blazor
 
+@* Input/change events are wired through the shared input.js module (see OnAfterRenderAsync)
+   so debouncing runs in the browser without a per-keystroke round-trip. *@
 <textarea
-    id="@Id"
+    id="@EffectiveId"
     data-slot="input-group-control"
     class="@CssClass"
     rows="@Rows"
@@ -11,7 +13,5 @@
     aria-label="@AriaLabel"
     aria-describedby="@AriaDescribedBy"
     aria-invalid="@(AriaInvalid?.ToString().ToLower())"
-    @oninput="HandleInput"
-    @onchange="HandleChange"
     @attributes="AdditionalAttributes"
     @ref="textareaReference">@Value</textarea>

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor.cs
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor.cs
@@ -263,9 +263,15 @@ public partial class InputGroupTextarea : ComponentBase, IAsyncDisposable
 
         try
         {
-            if (_jsInitialized && _inputModule is not null)
+            if (_inputModule is not null)
             {
-                await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                // Dispose the module even if initializeInput threw after a successful import.
+                // Only tear down JS-side state when initialization actually completed.
+                if (_jsInitialized)
+                {
+                    await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                }
+
                 await _inputModule.DisposeAsync();
             }
         }

--- a/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor.cs
+++ b/src/NeoUI.Blazor/Components/InputGroup/InputGroupTextarea.razor.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
 
 namespace NeoUI.Blazor;
 
@@ -19,6 +20,7 @@ namespace NeoUI.Blazor;
 /// - Flexible height based on content
 /// - Resize control options
 /// - Automatic marking for parent detection
+/// - Optional input debouncing via <see cref="DebounceDelay"/> (handled in JS, no per-keystroke round-trip)
 /// </para>
 /// </remarks>
 /// <example>
@@ -31,9 +33,33 @@ namespace NeoUI.Blazor;
 /// &lt;/InputGroup&gt;
 /// </code>
 /// </example>
-public partial class InputGroupTextarea : ComponentBase
+public partial class InputGroupTextarea : ComponentBase, IAsyncDisposable
 {
     private ElementReference textareaReference;
+
+    /// <summary>
+    /// Reference to the shared input JavaScript module.
+    /// </summary>
+    private IJSObjectReference? _inputModule;
+
+    /// <summary>
+    /// DotNet object reference for JavaScript callbacks.
+    /// </summary>
+    private DotNetObjectReference<InputGroupTextarea>? _dotNetRef;
+
+    /// <summary>
+    /// Tracks whether the JavaScript module has been initialized.
+    /// </summary>
+    private bool _jsInitialized;
+
+    /// <summary>
+    /// Auto-generated ID used when the user does not provide one, so JS can reference the element.
+    /// </summary>
+    private string? _generatedId;
+
+    [Inject]
+    private IJSRuntime JSRuntime { get; set; } = default!;
+
     /// <summary>
     /// Gets or sets the current value of the textarea.
     /// </summary>
@@ -86,6 +112,31 @@ public partial class InputGroupTextarea : ComponentBase
     public string? Id { get; set; }
 
     /// <summary>
+    /// Gets or sets when the textarea should update its bound value.
+    /// </summary>
+    /// <remarks>
+    /// - Input: Updates value on every input event (keystroke). Required for <see cref="DebounceDelay"/> to apply.
+    /// - Change: Updates value only when the textarea loses focus.
+    /// Defaults to <see cref="InputUpdateMode.Input"/> to preserve InputGroupTextarea's historical
+    /// update-on-keystroke behavior.
+    /// </remarks>
+    [Parameter]
+    public InputUpdateMode UpdateOn { get; set; } = InputUpdateMode.Input;
+
+    /// <summary>
+    /// Gets or sets the debounce delay in milliseconds before triggering value change notifications.
+    /// Only applies when <see cref="UpdateOn"/> is <see cref="InputUpdateMode.Input"/>. Set to 0 for immediate updates.
+    /// Default: 0 (no debounce)
+    /// </summary>
+    /// <remarks>
+    /// Debouncing is handled inside the shared input JavaScript module, so intermediate keystrokes
+    /// do not round-trip to the server (Blazor Server) or spin the renderer (WebAssembly). Only the
+    /// final, debounced value is dispatched to <see cref="ValueChanged"/>.
+    /// </remarks>
+    [Parameter]
+    public int DebounceDelay { get; set; } = 0;
+
+    /// <summary>
     /// Gets or sets the ARIA label.
     /// </summary>
     [Parameter]
@@ -110,6 +161,22 @@ public partial class InputGroupTextarea : ComponentBase
     public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     /// <summary>
+    /// Gets the effective ID, generating a unique one when none is provided so JS can always
+    /// reference the element.
+    /// </summary>
+    private string EffectiveId
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(Id))
+                return Id;
+
+            _generatedId ??= "input-group-textarea-" + Guid.NewGuid().ToString("N")[..6];
+            return _generatedId;
+        }
+    }
+
+    /// <summary>
     /// Gets the computed CSS classes for the textarea element.
     /// </summary>
     /// <remarks>
@@ -131,29 +198,84 @@ public partial class InputGroupTextarea : ComponentBase
     );
 
     /// <summary>
-    /// Handles the input event (fired on every keystroke).
+    /// Sets up input event handling (UpdateOn mode + debounce) through the shared input JS module.
     /// </summary>
-    private async Task HandleInput(ChangeEventArgs args)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var newValue = args.Value?.ToString();
-        Value = newValue;
+        if (!firstRender)
+            return;
 
-        if (ValueChanged.HasDelegate)
+        try
         {
-            await ValueChanged.InvokeAsync(newValue);
+            _inputModule = await JSRuntime.InvokeAsync<IJSObjectReference>(
+                "import", "./_content/NeoUI.Blazor/js/input.js");
+
+            _dotNetRef = DotNetObjectReference.Create(this);
+
+            // Initialize input event handling with UpdateOn mode and debounce.
+            // The JS module owns the debounce timer, so intermediate keystrokes never
+            // cross the circuit — only the final value invokes OnInputChanged.
+            await _inputModule.InvokeVoidAsync(
+                "initializeInput",
+                EffectiveId,
+                UpdateOn.ToString().ToLower(),
+                DebounceDelay,
+                _dotNetRef
+            );
+
+            _jsInitialized = true;
+        }
+        catch (Exception ex) when (ex is JSException or JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // JS module not available (e.g. circuit disconnect); the element still renders,
+            // value simply won't be wired through JS event handling.
         }
     }
 
     /// <summary>
-    /// Handles the change event (fired when textarea loses focus).
+    /// Called from JavaScript when the textarea value changes, based on UpdateOn mode and debounce settings.
     /// </summary>
-    private async Task HandleChange(ChangeEventArgs args)
+    /// <param name="value">The new textarea value.</param>
+    [JSInvokable]
+    public async Task OnInputChanged(string? value)
     {
-        await Task.CompletedTask;
+        Value = value;
+
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(value);
+        }
+
+        // Deliberately no StateHasChanged() here to avoid re-rendering (and cursor jumps) during typing.
     }
 
     /// <summary>
-    /// Moves keyboard focus to the input element.
+    /// Moves keyboard focus to the textarea element.
     /// </summary>
     public ValueTask FocusAsync() => textareaReference.FocusAsync();
+
+    /// <summary>
+    /// Disposes the JavaScript module, event handlers, and object references.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+
+        try
+        {
+            if (_jsInitialized && _inputModule is not null)
+            {
+                await _inputModule.InvokeVoidAsync("disposeInput", EffectiveId);
+                await _inputModule.DisposeAsync();
+            }
+        }
+        catch (Exception ex) when (ex is JSException or JSDisconnectedException or TaskCanceledException or ObjectDisposedException)
+        {
+            // JS runtime already gone; nothing to clean up.
+        }
+
+        _inputModule = null;
+        _dotNetRef?.Dispose();
+        _dotNetRef = null;
+    }
 }


### PR DESCRIPTION
## What this is

A **draft alternative implementation** of the `DebounceDelay` feature proposed in #201, for @Smegfi to review and test. It keeps the same public API (`DebounceDelay`) and demos, but implements debouncing the way the rest of the input family already does it.

> **Note on the base:** this branch is cut from **current `main`**, not from #201's branch. #201 branched before #199 (input-group-focus) merged, so it currently conflicts with `main` (`mergeable_state: dirty`). Basing here keeps #199's `FocusAsync` intact and produces a clean, mergeable diff. The component files here are a superset — they include both `FocusAsync` and the debounce feature.

## Why change the approach

#201 debounces in C# with `Task.Delay` + `CancellationTokenSource` inside an `@oninput` handler. Every other input component that exposes `DebounceDelay` — **Input, Textarea, NumericInput, CurrencyInput, MaskedInput** — debounces in the shared `input.js` module (`initializeInput`), gated by an `UpdateOn` mode. This PR aligns `InputGroupInput` / `InputGroupTextarea` with that established pattern.

Concrete benefits over the C# approach:

- **Performance / no per-keystroke round-trip.** With `@oninput` bound to a C# handler, *every* keystroke is dispatched across the SignalR circuit (Blazor Server) or spins the renderer (WASM) — the `Task.Delay` only delays `ValueChanged`, it does not stop the round-trip. With the JS module, the debounce timer runs in the browser and only the final value crosses to .NET.
- **Consistency.** Same wiring, same `UpdateOn` semantics, same `[JSInvokable] OnInputChanged` callback as the other inputs.
- **Lifecycle correctness.** Both components now implement `IAsyncDisposable` and dispose the JS module + `DotNetObjectReference`. This removes the `CancellationTokenSource` leak the reviewer flagged (the CTS was replaced each keystroke and never disposed, and the components weren't disposable at all).

## Changes

- `InputGroupInput` / `InputGroupTextarea`: route input/change events through `input.js`; add `UpdateOn` (`InputUpdateMode`) + `DebounceDelay`; implement `IAsyncDisposable`; generate an `EffectiveId` so JS can always target the element.
- Demos: add the **Two-Way Binding** and **Debounce** sections, and align the two-way sample label (`Search:`) with its live output (previously showed `Text:`).

## Behavior note for review

`UpdateOn` defaults to `InputUpdateMode.Input` here (update on keystroke) to preserve InputGroup's historical behavior and keep `DebounceDelay` meaningful by default. The standalone `Input` defaults to `Change`. Happy to flip this if you'd prefer strict parity with `Input`.

## Testing

Not yet built/run in this environment (no .NET SDK available here) — please pull and try the InputGroup demo page (Two-Way Binding + Debounce sections). Verified by static review: no dangling handler references, clean superset of `main`'s InputGroup components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xb2kqNdzS5Y2VnAcrq2zum

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb2kqNdzS5Y2VnAcrq2zum)_