### PR TITLE
fix(positioning): honor assigned z-index so nested overlays stack correctly

### DIFF
--- a/src/NeoUI.Blazor.Primitives/Primitives/Menubar/MenubarSubContentPrimitive.razor
+++ b/src/NeoUI.Blazor.Primitives/Primitives/Menubar/MenubarSubContentPrimitive.razor
@@ -84,7 +84,7 @@ private readonly List<IMenubarItem> _menuItems = new();
     /// <summary>
     /// Gets the effective z-index value, calculating from depth if not explicitly set.
     /// </summary>
-    private int EffectiveZIndex => 9999; // Use special zIndex value for sub menus
+    private int EffectiveZIndex => ZIndex ?? (ZIndexLevels.PopoverContent + (SubContext?.Depth ?? 0));
 
     protected override void OnInitialized()
     {

--- a/src/NeoUI.Blazor.Primitives/Primitives/Select/SelectContentPrimitive.razor
+++ b/src/NeoUI.Blazor.Primitives/Primitives/Select/SelectContentPrimitive.razor
@@ -21,7 +21,6 @@
                 ForceMount="@ForceMount"
                 MatchAnchorWidth="@MatchTriggerWidth"
                 Strategy="PositioningStrategy.Fixed"
-                ZIndex="9999"
                 OnReady="@HandleFloatingReady">
     @RenderSelectListbox()
 </FloatingPortal>

--- a/src/NeoUI.Blazor.Primitives/wwwroot/js/primitives/positioning.js
+++ b/src/NeoUI.Blazor.Primitives/wwwroot/js/primitives/positioning.js
@@ -296,9 +296,13 @@ export async function computePosition(reference, floating, options = {}) {
 export function applyPosition(floating, position, makeVisible = false) {
   if (!floating || !position) return;
 
-  // Apply all positioning styles atomically to prevent flash
-  // Use higher z-index for fixed positioning (nested dropdowns) to ensure they appear above parent popovers
-  const zIndex = position.strategy === 'fixed' ? '9999' : floatingZIndex;
+  // Apply all positioning styles atomically to prevent flash.
+  // Honor the z-index already assigned to the element (written inline by FloatingPortal
+  // from its ZIndex parameter). Fall back to the default popover level only when nothing
+  // has been set. Previously this hardcoded 9999 for every fixed-strategy element, which
+  // flattened all popovers/selects/dropdowns onto the same layer — so an overlay opened
+  // on top of a fixed-strategy popover would render *behind* it.
+  const zIndex = floating.style.zIndex || floatingZIndex;
   Object.assign(floating.style, {
     position: position.strategy || 'absolute',
     left: `${position.x}px`,


### PR DESCRIPTION
## Problem
A `Strategy=Fixed` Popover appeared with `z-index: 9999`, so any overlay opened on top of it (e.g. a nested `DropdownMenu` wired via `ParentPortalId`) rendered **behind** it.

## Root cause
`positioning.js` `applyPosition()` hardcoded `z-index: 9999` for every fixed-strategy floating element, flattening all popovers/selects/dropdowns to the same layer. Since an appended child portal is rendered as a **later sibling** in the composite portal (`PortalService.CreateCompositeFragment`), sibling stacking is decided by z-index first and DOM order only on ties — so the fixed popover at 9999 outranked the nested menu at its real level (60).

## Fix
- **positioning.js** — honor the z-index `FloatingPortal` already writes inline from its `ZIndex` parameter (fallback: default popover level). Fixed strategy no longer forces 9999.
- **SelectContentPrimitive / MenubarSubContentPrimitive** — drop the redundant hardcoded `9999`; resolve through `ZIndexLevels` (Menubar submenus use `PopoverContent + depth`, per their own doc comment).

## Verification
Drove the previously-broken scenario in the running demo — a fixed-strategy Popover with a nested `DropdownMenu` (`ParentPortalId`): both compute `z-index: 60` and the menu paints on top of the popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)