### PR TITLE
chore(components): reference NeoUI.Blazor.Primitives 4.0.7

### DIFF
--- a/src/NeoUI.Blazor/NeoUI.Blazor.csproj
+++ b/src/NeoUI.Blazor/NeoUI.Blazor.csproj
@@ -50,7 +50,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="NeoUI.Icons.Lucide" Version="3.0.0" />
-    <PackageReference Include="NeoUI.Blazor.Primitives" Version="4.0.6" />
+    <PackageReference Include="NeoUI.Blazor.Primitives" Version="4.0.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps the packed `NeoUI.Blazor.Primitives` PackageReference from 4.0.6 → 4.0.7 so the `NeoUI.Blazor` components package ships the nested-overlay z-index fix (#205).

Required before tagging `components/v4.1.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)