### PR TITLE
fix(sortable): stop drag ghost drifting when Sortable is used inside a Dialog

### DIFF
--- a/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/SortableDemo.cs
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/SortableDemo.cs
@@ -2,6 +2,41 @@ namespace NeoUI.Demo.Shared.Pages.Components
 {
     partial class SortableDemo
     {
+        private const string _dialogCode =
+            """
+            @* Sortable works inside a Dialog. The dialog centres itself with a CSS
+               transform, which makes position:fixed resolve against the dialog rather
+               than the viewport — the drag overlay compensates automatically, so the
+               ghost tracks the cursor without drifting. No extra configuration needed. *@
+            <Dialog>
+                <DialogTrigger AsChild>
+                    <Button Variant="ButtonVariant.Outline">Reorder in dialog</Button>
+                </DialogTrigger>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Reorder tasks</DialogTitle>
+                    </DialogHeader>
+                    <Sortable TItem="MyItem"
+                              Items="@items"
+                              OnItemsReordered="@(r => items = r)"
+                              GetItemId="@(i => i.Id)">
+                        <SortableContent Class="block">
+                            <DataView Items="@items" ItemKey="@(i => i.Id)"
+                                      ShowToolbar="false" ShowPagination="false">
+                                <ListTemplate Context="item">
+                                    <SortableItem Value="@item.Id">
+                                        <SortableItemHandle />
+                                        <span class="flex-1 text-sm font-medium select-none">@item.Name</span>
+                                    </SortableItem>
+                                </ListTemplate>
+                            </DataView>
+                        </SortableContent>
+                        <SortableOverlay />
+                    </Sortable>
+                </DialogContent>
+            </Dialog>
+            """;
+
         private const string _defaultCode =
             """
             <Sortable TItem="MyItem"

--- a/demo/NeoUI.Demo.Shared/Pages/Components/SortableDemo.razor
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/SortableDemo.razor
@@ -217,6 +217,44 @@
         </DemoBlock>
     </DemoSection>
 
+    @* ── Inside a Dialog ─────────────────────────────────────── *@
+    <DemoSection Title="Inside a Dialog"
+                 Description="Sortable works inside a Dialog even though the dialog centres itself with a CSS transform. The drag overlay detects the transformed containing block on drag start and compensates, so the ghost stays under the cursor instead of drifting.">
+        <DemoBlock Code="@_dialogCode">
+            <Dialog>
+                <DialogTrigger AsChild>
+                    <Button Variant="ButtonVariant.Outline">Reorder in dialog</Button>
+                </DialogTrigger>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Reorder tasks</DialogTitle>
+                        <DialogDescription>Drag the handles to reorder. The ghost should track the cursor exactly.</DialogDescription>
+                    </DialogHeader>
+                    <Sortable TItem="CardItem"
+                              Items="@_dialogItems"
+                              OnItemsReordered="@(r => _dialogItems = r)"
+                              OnDragEnd="@(e => ShowDragEndToast(e, _dialogItems.ElementAtOrDefault(e.Moved ? e.ToIndex : e.FromIndex)?.Name))"
+                              OnDragCancel="@ShowDragCancelToast"
+                              GetItemId="@(i => i.Id)">
+                        <SortableContent Class="block">
+                            <DataView Items="@_dialogItems" ItemKey="@(i => i.Id)"
+                                      ShowToolbar="false" ShowPagination="false">
+                                <ListTemplate Context="item">
+                                    <SortableItem @key="@item.Id" Value="@item.Id" Class="-mx-1 rounded-none border-0 border-b last:border-b-0 shadow-none px-2">
+                                        <SortableItemHandle />
+                                        <span class="flex-1 text-sm font-medium select-none">@item.Name</span>
+                                        <Badge Variant="BadgeVariant.Secondary" Class="text-xs">@item.Tag</Badge>
+                                    </SortableItem>
+                                </ListTemplate>
+                            </DataView>
+                        </SortableContent>
+                        <SortableOverlay />
+                    </Sortable>
+                </DialogContent>
+            </Dialog>
+        </DemoBlock>
+    </DemoSection>
+
     @* ── Kanban Board (cross-list) ───────────────────────────── *@
     <DemoSection Title="Kanban Board"
                  Description="Items drag freely between columns using the Group parameter. OnItemTransferredOut removes the item from its source list; OnItemTransferredIn inserts it into the target.">
@@ -446,6 +484,14 @@
         new("dv3", "Implement API",      "Backend"),
         new("dv4", "Code review",        "DevOps"),
         new("dv5", "Deploy to staging",  "Ops"),
+    ];
+
+    private IList<CardItem> _dialogItems =
+    [
+        new("dlg1", "Draft proposal",   "Docs"),
+        new("dlg2", "Review budget",    "Finance"),
+        new("dlg3", "Schedule kickoff", "Ops"),
+        new("dlg4", "Assign owners",    "Team"),
     ];
 
     private IList<CardItem> _dataViewGridItems =

--- a/src/NeoUI.Blazor.Primitives/wwwroot/js/primitives/sortable.js
+++ b/src/NeoUI.Blazor.Primitives/wwwroot/js/primitives/sortable.js
@@ -39,6 +39,32 @@ function getOverlay(instanceId) {
     return document.querySelector(`[data-sortable-overlay-for="${instanceId}"]`);
 }
 
+/**
+ * The overlay is position:fixed and moved with viewport (client) coordinates. That only lands
+ * correctly when its containing block is the viewport. If an ancestor has a transform — e.g. a
+ * Dialog centres its panel with `translate(-50%,-50%)` (and animates with `zoom-*`) — that
+ * ancestor becomes the containing block instead, so viewport coordinates are offset by the
+ * ancestor's on-screen position and the dragged ghost drifts away from the pointer.
+ *
+ * Measure that offset once at drag start (set the overlay to a known viewport point, read back
+ * where it actually rendered, take the delta) and add it on every subsequent move. Zero overhead
+ * and a no-op when there is no transformed ancestor. Requires the overlay to be display:block.
+ */
+function measureOverlayCorrection(state, overlay, vx, vy) {
+    overlay.style.left = vx + 'px';
+    overlay.style.top  = vy + 'px';
+    const r = overlay.getBoundingClientRect();
+    state.overlayCorrectionX = vx - r.left;
+    state.overlayCorrectionY = vy - r.top;
+}
+
+/** Positions a position:fixed overlay so its top-left lands at viewport point (vx, vy),
+ *  compensating for a transformed ancestor (see measureOverlayCorrection). */
+function setOverlayPos(state, overlay, vx, vy) {
+    overlay.style.left = (vx + (state.overlayCorrectionX || 0)) + 'px';
+    overlay.style.top  = (vy + (state.overlayCorrectionY || 0)) + 'px';
+}
+
 /** Returns the instanceIds of all other instances in the same group. */
 function getGroupPeers(state) {
     if (!state.group) return [];
@@ -455,10 +481,12 @@ function startDrag(state, orientation) {
 
         overlay.style.width   = activeRect.width  + 'px';
         overlay.style.height  = activeRect.height + 'px';
-        overlay.style.left    = activeRect.left   + 'px';
-        overlay.style.top     = activeRect.top    + 'px';
         overlay.style.display = 'block';
         overlay.setAttribute('data-state', 'dragging');
+
+        // Compensate for any transformed ancestor (e.g. a Dialog) breaking fixed positioning.
+        measureOverlayCorrection(state, overlay, activeRect.left, activeRect.top);
+        setOverlayPos(state, overlay, activeRect.left, activeRect.top);
 
         // Clone source element into overlay if no custom child content.
         // Skip if the overlay declares custom ChildContent via data-has-child-content —
@@ -484,8 +512,7 @@ function moveDrag(state, x, y, orientation) {
 
     const overlay = getOverlay(state.instanceId);
     if (overlay) {
-        overlay.style.left = (x - state.offsetX) + 'px';
-        overlay.style.top  = (y - state.offsetY)  + 'px';
+        setOverlayPos(state, overlay, x - state.offsetX, y - state.offsetY);
     }
 
     applyItemTransforms(state, orientation);
@@ -781,10 +808,11 @@ function buildKeyboardHandlers(state, orientation) {
             if (overlay) {
                 overlay.style.width   = rect.width  + 'px';
                 overlay.style.height  = rect.height + 'px';
-                overlay.style.left    = rect.left   + 'px';
-                overlay.style.top     = rect.top    + 'px';
                 overlay.style.display = 'block';
                 overlay.setAttribute('data-state', 'dragging');
+                // Compensate for any transformed ancestor (e.g. a Dialog) breaking fixed positioning.
+                measureOverlayCorrection(state, overlay, rect.left, rect.top);
+                setOverlayPos(state, overlay, rect.left, rect.top);
                 if (overlay.childElementCount === 0 && !overlay.dataset.hasChildContent) {
                     setupCloneInOverlay(overlay, item);
                     state.overlayCloned = true;

--- a/src/NeoUI.Blazor/NeoUI.Blazor.csproj
+++ b/src/NeoUI.Blazor/NeoUI.Blazor.csproj
@@ -50,7 +50,7 @@
 
   <ItemGroup Condition="'$(UsePackageReferences)' == 'true'">
     <PackageReference Include="NeoUI.Icons.Lucide" Version="3.0.0" />
-    <PackageReference Include="NeoUI.Blazor.Primitives" Version="4.0.8" />
+    <PackageReference Include="NeoUI.Blazor.Primitives" Version="4.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem
Inside a `Dialog`, the Sortable drag ghost drifts away from the cursor. The overlay is `position: fixed` and moved with viewport coordinates, which only works when its containing block is the viewport. A Dialog centres its panel with `translate(-50%,-50%)` (+ `zoom` entrance) — `DialogContent.razor:162,185` — and per CSS spec a **transformed ancestor becomes the containing block** for `position: fixed` descendants. So the overlay's coordinates resolved against the dialog, not the viewport, and the ghost drifted by the dialog's on-screen offset.

## Fix (`sortable.js`)
Measure the offset once at drag start (set the overlay to a known viewport point, read back where it rendered, take the delta) and add it on every move — `measureOverlayCorrection` / `setOverlayPos`, applied at all three positioning sites (pointer drag-start, keyboard drag-start, `moveDrag`). Zero overhead and a **no-op when there is no transformed ancestor**.

## Demo
Adds an **"Inside a Dialog"** section to `/components/sortable` (Sortable + DataView inside a Dialog) — the exact reported scenario, so it's covered going forward.

## Verification
Scripted drag inside the dialog: **0px drift** (was ~285px). Counter-test with the correction disabled still reports the drift, confirming the harness detects it.

Also bumps the components package's `NeoUI.Blazor.Primitives` reference to **4.0.9** (primitives is transitive in components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)