### PR TITLE
feat(datatable): persist view state (page size, page, sort) via StateKey

### DIFF
--- a/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/DataTableDemo.cs
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/CodeExamples/DataTableDemo.cs
@@ -16,6 +16,7 @@ namespace NeoUI.Demo.Shared.Pages.Components
                 new("IsLoading", "bool", "false", "Shows a loading indicator instead of table content."),
                 new("InitialPageSize", "int", "5", "The initial number of rows per page."),
                 new("PageSizes", "int[]", "[5,10,20,50,100]", "Available page size options in the pagination selector."),
+                new("StateKey", "string?", "null", "When set, persists the table's view state (page size, current page, sort) per key across navigation and reloads (localStorage + cookie)."),
                 new("Dense", "bool", "true", "Compact cell padding (header h-9, body py-2 px-4). When false, uses h-12 / p-4."),
                 new("HeaderBackground", "bool", "true", "Applies bg-muted/50 to the header row."),
                 new("HeaderBorder", "bool", "false", "Vertical dividers between header cells (divide-x divide-border)."),
@@ -73,6 +74,30 @@ namespace NeoUI.Demo.Shared.Pages.Components
                 new("Resizable", "bool?", "null", "Per-column resize override. null inherits the table-level Resizable setting."),
                 new("Reorderable", "bool?", "null", "Per-column reorder override. null inherits the table-level Reorderable setting. Pinned columns and the selection column are always excluded."),
             ];
+
+        private const string _statePersistenceCode = """
+                @* Give the table a stable StateKey to auto-persist page size, current page and sort.
+                   The state survives tab switches (unmount/remount), navigation and full reloads —
+                   stored per key in localStorage with a cookie mirror for SSR. Omit StateKey to opt out. *@
+                <Tabs DefaultValue="table">
+                    <TabsList>
+                        <TabsTrigger Value="table">People</TabsTrigger>
+                        <TabsTrigger Value="other">Other tab</TabsTrigger>
+                    </TabsList>
+                    <TabsContent Value="table">
+                        <DataTable TData="Person" Data="people" StateKey="demo-people" InitialPageSize="5">
+                            <Columns>
+                                <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
+                                <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Email)" Header="Email" Sortable />
+                                <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable />
+                            </Columns>
+                        </DataTable>
+                    </TabsContent>
+                    <TabsContent Value="other">
+                        <p>Switch away and back — the People tab keeps its page size, page and sort.</p>
+                    </TabsContent>
+                </Tabs>
+                """;
 
         private const string _basicTableCode = """
                 <DataTable TData="Person"

--- a/demo/NeoUI.Demo.Shared/Pages/Components/DataTableDemo.razor
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/DataTableDemo.razor
@@ -571,6 +571,45 @@
     </DemoSection>
 
     <DemoSection
+        Title="State Persistence"
+        Description="Set a stable StateKey to automatically persist page size, current page and sort per table. State survives tab switches (the inactive tab unmounts), navigation and full reloads — stored in localStorage with a cookie mirror for SSR. Try it: change the page size / sort a column / go to page 2, switch to 'Other tab', switch back — it's preserved. Omit StateKey to opt out (the second table below still resets).">
+        <DemoBlock Code="@_statePersistenceCode">
+            <Tabs DefaultValue="table">
+                <TabsList>
+                    <TabsTrigger Value="table">People (StateKey)</TabsTrigger>
+                    <TabsTrigger Value="other">Other tab</TabsTrigger>
+                </TabsList>
+                <TabsContent Value="table">
+                    <div class="space-y-6">
+                        <div>
+                            <p class="text-sm font-medium mb-2">With <code>StateKey="demo-people"</code> — persists</p>
+                            <DataTable TData="Person" Data="@people" StateKey="demo-people" InitialPageSize="5">
+                                <Columns>
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Email)" Header="Email" Sortable />
+                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
+                                </Columns>
+                            </DataTable>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium mb-2">No StateKey — resets on tab switch</p>
+                            <DataTable TData="Person" Data="@people" InitialPageSize="5">
+                                <Columns>
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
+                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
+                                </Columns>
+                            </DataTable>
+                        </div>
+                    </div>
+                </TabsContent>
+                <TabsContent Value="other">
+                    <p class="text-sm text-muted-foreground p-6">Switch back to the People tab — the keyed table keeps its page size, page and sort; the unkeyed one resets.</p>
+                </TabsContent>
+            </Tabs>
+        </DemoBlock>
+    </DemoSection>
+
+    <DemoSection
         Title="DataTable API"
         Description="DataTable component parameters and their types.">
         <DemoPropsTable Rows="_dataTableProps" />

--- a/demo/NeoUI.Demo.Shared/Pages/Components/DataTableDemo.razor
+++ b/demo/NeoUI.Demo.Shared/Pages/Components/DataTableDemo.razor
@@ -527,6 +527,45 @@
     </DemoSection>
 
     <DemoSection
+        Title="State Persistence"
+        Description="Set a stable StateKey to automatically persist page size, current page and sort per table. State survives tab switches (the inactive tab unmounts), navigation and full reloads — stored in localStorage with a cookie mirror for SSR. Try it: change the page size / sort a column / go to page 2, switch to 'Other tab', switch back — it's preserved. Omit StateKey to opt out (the second table below still resets).">
+        <DemoBlock Code="@_statePersistenceCode">
+            <Tabs DefaultValue="table">
+                <TabsList>
+                    <TabsTrigger Value="table">People (StateKey)</TabsTrigger>
+                    <TabsTrigger Value="other">Other tab</TabsTrigger>
+                </TabsList>
+                <TabsContent Value="table">
+                    <div class="space-y-6">
+                        <div>
+                            <p class="text-sm font-medium mb-2">With <code>StateKey="demo-people"</code> — persists</p>
+                            <DataTable TData="Person" Data="@people" StateKey="demo-people" InitialPageSize="5">
+                                <Columns>
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Email)" Header="Email" Sortable />
+                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
+                                </Columns>
+                            </DataTable>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium mb-2">No StateKey — resets on tab switch</p>
+                            <DataTable TData="Person" Data="@people" InitialPageSize="5">
+                                <Columns>
+                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
+                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
+                                </Columns>
+                            </DataTable>
+                        </div>
+                    </div>
+                </TabsContent>
+                <TabsContent Value="other">
+                    <p class="text-sm text-muted-foreground p-6">Switch back to the People tab — the keyed table keeps its page size, page and sort; the unkeyed one resets.</p>
+                </TabsContent>
+            </Tabs>
+        </DemoBlock>
+    </DemoSection>
+
+    <DemoSection
         Title="Accessibility Features"
         Description="Built-in accessibility features following WAI-ARIA design patterns.">
         <div class="rounded-md border p-4 space-y-4">
@@ -568,45 +607,6 @@
                 <kbd class="px-2 py-1 bg-muted rounded text-sm font-mono">Click</kbd>
             </div>
         </div>
-    </DemoSection>
-
-    <DemoSection
-        Title="State Persistence"
-        Description="Set a stable StateKey to automatically persist page size, current page and sort per table. State survives tab switches (the inactive tab unmounts), navigation and full reloads — stored in localStorage with a cookie mirror for SSR. Try it: change the page size / sort a column / go to page 2, switch to 'Other tab', switch back — it's preserved. Omit StateKey to opt out (the second table below still resets).">
-        <DemoBlock Code="@_statePersistenceCode">
-            <Tabs DefaultValue="table">
-                <TabsList>
-                    <TabsTrigger Value="table">People (StateKey)</TabsTrigger>
-                    <TabsTrigger Value="other">Other tab</TabsTrigger>
-                </TabsList>
-                <TabsContent Value="table">
-                    <div class="space-y-6">
-                        <div>
-                            <p class="text-sm font-medium mb-2">With <code>StateKey="demo-people"</code> — persists</p>
-                            <DataTable TData="Person" Data="@people" StateKey="demo-people" InitialPageSize="5">
-                                <Columns>
-                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
-                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Email)" Header="Email" Sortable />
-                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
-                                </Columns>
-                            </DataTable>
-                        </div>
-                        <div>
-                            <p class="text-sm font-medium mb-2">No StateKey — resets on tab switch</p>
-                            <DataTable TData="Person" Data="@people" InitialPageSize="5">
-                                <Columns>
-                                    <DataTableColumn TData="Person" TValue="string" Property="@(p => p.Name)" Header="Name" Sortable />
-                                    <DataTableColumn TData="Person" TValue="int" Property="@(p => p.Age)" Header="Age" Sortable Alignment="ColumnAlignment.Right" />
-                                </Columns>
-                            </DataTable>
-                        </div>
-                    </div>
-                </TabsContent>
-                <TabsContent Value="other">
-                    <p class="text-sm text-muted-foreground p-6">Switch back to the People tab — the keyed table keeps its page size, page and sort; the unkeyed one resets.</p>
-                </TabsContent>
-            </Tabs>
-        </DemoBlock>
     </DemoSection>
 
     <DemoSection

--- a/src/NeoUI.Blazor/Components/DataTable/DataTable.razor
+++ b/src/NeoUI.Blazor/Components/DataTable/DataTable.razor
@@ -264,7 +264,8 @@
 
         @if (ShowPagination && !IsLoading && !IsVirtualized && !IsTreeMode && _processedData.Any())
         {
-            <Pagination State="@_tableState.Pagination"
+            <Pagination @key="_stateRestoreKey"
+                        State="@_tableState.Pagination"
                         PageSizes="@PageSizes"
                         OnPageChanged="@HandlePageChanged"
                         OnPageSizeChanged="@HandlePageSizeChanged"

--- a/src/NeoUI.Blazor/Components/DataTable/DataTable.razor.cs
+++ b/src/NeoUI.Blazor/Components/DataTable/DataTable.razor.cs
@@ -1,9 +1,13 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using NeoUI.Blazor.Primitives;
+using NeoUI.Blazor.Services;
 
 namespace NeoUI.Blazor;
 
@@ -132,6 +136,26 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
 
     [Inject]
     private ILocalizer Localizer { get; set; } = default!;
+
+    // Generic keyed store (localStorage + cookie) used to persist view state per StateKey.
+    [Inject]
+    private KeyedStateService StateStore { get; set; } = default!;
+
+    // Framework state used for the SSR→interactive handover of restored view state.
+    [Inject]
+    private PersistentComponentState PersistentState { get; set; } = default!;
+
+    // Resolves IHttpContextAccessor (Server/SSR only) for the cookie restore tier.
+    [Inject]
+    private IServiceProvider ServiceProvider { get; set; } = default!;
+
+    private PersistingComponentStateSubscription _persistingSubscription;
+    private bool _stateRestored;
+    // Bumped when an async (post-first-render) restore changes state, to re-key the Pagination so its
+    // page-size selector re-initializes to the restored value (it only reads state on mount).
+    private int _stateRestoreKey;
+    private bool HasStateKey => !string.IsNullOrWhiteSpace(StateKey);
+    private string PersistenceKey => $"DataTableState_{StateKey}";
 
     /// <summary>
     /// Stores the list of registered column definitions.
@@ -534,6 +558,16 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
     public int InitialPageSize { get; set; } = 5;
 
     /// <summary>
+    /// Gets or sets a stable, app-unique key that enables automatic persistence of this table's
+    /// view state — page size, current page, and sort — across navigation and reloads.
+    /// When null or empty (the default), nothing is persisted and behavior is unchanged.
+    /// State is stored per key in localStorage (with a cookie mirror for SSR pre-render) under the
+    /// <c>neoui:state:</c> prefix.
+    /// </summary>
+    [Parameter]
+    public string? StateKey { get; set; }
+
+    /// <summary>
     /// Gets or sets custom toolbar actions (buttons, etc.).
     /// </summary>
     [Parameter]
@@ -920,6 +954,122 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
         _tableState.Pagination.CurrentPage = 1;
         // Set selection mode on the state so Select/Deselect methods work correctly
         _tableState.Selection.Mode = GetPrimitiveSelectionMode();
+
+        // Opt-in view-state persistence: restore from synchronous sources here (PersistentComponentState
+        // for the SSR→interactive handover, cookie for server pre-render) so the very first render already
+        // reflects the saved page size/page/sort. The async localStorage fallback runs in OnAfterRenderAsync.
+        if (HasStateKey)
+        {
+            TryRestoreSyncState();
+            _persistingSubscription = PersistentState.RegisterOnPersisting(PersistState);
+        }
+    }
+
+    // ── View-state persistence (opt-in via StateKey) ─────────────────────────
+
+    /// <summary>Restores view state from the synchronous sources: PersistentComponentState, then cookie.</summary>
+    private void TryRestoreSyncState()
+    {
+        // Tier 0 — in-memory cache on the (circuit/app-scoped) store. This is the freshest source and,
+        // crucially, synchronous: it lets a remount within the same session (e.g. switching back to a
+        // tab) restore BEFORE the first render, so there's no flicker from a post-render async read.
+        if (StateStore.TryGetCached(StateKey!, out var cached) && TryDeserialize(cached, out var fromCache))
+        {
+            ApplyViewState(fromCache);
+            _stateRestored = true;
+            return;
+        }
+
+        // Tier 1 — PersistentComponentState (seamless SSR → interactive handover).
+        if (PersistentState.TryTakeFromJson<DataTableViewState>(PersistenceKey, out var persisted) && persisted is not null)
+        {
+            ApplyViewState(persisted);
+            _stateRestored = true;
+            return;
+        }
+
+        // Tier 2 — cookie, readable server-side during pre-render via IHttpContextAccessor.
+        var httpContext = ServiceProvider.GetService<IHttpContextAccessor>()?.HttpContext;
+        if (httpContext is null)
+            return;
+
+        var cookieKey = KeyedStateService.KeyPrefix + StateKey;
+        var cookies = httpContext.Request.Cookies;
+        string? cookieValue = null;
+        if (cookies.TryGetValue(Uri.EscapeDataString(cookieKey), out var encoded))
+            cookieValue = Uri.UnescapeDataString(encoded);
+        else if (cookies.TryGetValue(cookieKey, out var plain))
+            cookieValue = plain;
+
+        if (TryDeserialize(cookieValue, out var fromCookie))
+        {
+            ApplyViewState(fromCookie);
+            _stateRestored = true;
+        }
+    }
+
+    private static bool TryDeserialize(string? json, out DataTableViewState state)
+    {
+        state = default!;
+        if (string.IsNullOrEmpty(json))
+            return false;
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<DataTableViewState>(json);
+            if (parsed is null)
+                return false;
+            state = parsed;
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Applies a restored snapshot onto the internal table state (paging + sort).</summary>
+    private void ApplyViewState(DataTableViewState state)
+    {
+        // PageSize FIRST — the PaginationState.PageSize setter forces CurrentPage back to 1.
+        // Ignore a persisted size that is no longer offered so the selector doesn't render blank.
+        var size = (PageSizes is { Length: > 0 } && Array.IndexOf(PageSizes, state.PageSize) >= 0)
+            ? state.PageSize
+            : InitialPageSize;
+        _tableState.Pagination.PageSize = size;
+        _tableState.Pagination.CurrentPage = Math.Max(1, state.CurrentPage);
+        // TotalItems (set later in ProcessDataAsync) self-clamps CurrentPage to TotalPages.
+
+        // Safe even if the column isn't registered yet — sorting no-ops on an unknown id.
+        _tableState.Sorting.SortedColumn = state.SortedColumn;
+        _tableState.Sorting.Direction = state.Direction;
+    }
+
+    private DataTableViewState BuildViewState() => new()
+    {
+        PageSize = _tableState.Pagination.PageSize,
+        CurrentPage = _tableState.Pagination.CurrentPage,
+        SortedColumn = _tableState.Sorting.SortedColumn,
+        Direction = _tableState.Sorting.Direction,
+    };
+
+    /// <summary>Cheap equality key of the current view state, used to detect whether a restore changed anything.</summary>
+    private (int, int, string?, SortDirection) SnapshotKey() =>
+        (_tableState.Pagination.PageSize, _tableState.Pagination.CurrentPage, _tableState.Sorting.SortedColumn, _tableState.Sorting.Direction);
+
+    /// <summary>PersistentComponentState callback — hands the current view state to the client after pre-render.</summary>
+    private Task PersistState()
+    {
+        if (HasStateKey)
+            PersistentState.PersistAsJson(PersistenceKey, BuildViewState());
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Saves the current view state to client storage (localStorage + cookie). No-op without a StateKey.</summary>
+    private async Task PersistStateAsync()
+    {
+        if (!HasStateKey)
+            return;
+        await StateStore.SetStateAsync(StateKey!, JsonSerializer.Serialize(BuildViewState()));
     }
 
     /// <summary>
@@ -1236,11 +1386,13 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
         {
             await _virtualizeRef.RefreshDataAsync();
             StateHasChanged();
+            await PersistStateAsync();
             return;
         }
 
         await ProcessDataAsync();
         StateHasChanged();
+        await PersistStateAsync();
     }
 
     /// <summary>
@@ -1797,6 +1949,7 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
         _paginationVersion++;  // Track pagination change for ShouldRender
         await ProcessDataAsync();
         StateHasChanged();
+        await PersistStateAsync();
     }
 
     /// <summary>
@@ -1809,6 +1962,7 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
         _paginationVersion++;  // Track pagination change for ShouldRender
         await ProcessDataAsync();
         StateHasChanged();
+        await PersistStateAsync();
     }
 
     /// <summary>
@@ -1883,6 +2037,32 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // localStorage is the live source of truth — it is rewritten on every change, whereas the
+        // synchronous tiers used in OnInitialized can be stale: a PersistentComponentState snapshot
+        // is a one-shot handover payload that can resurface (with an old value) on a tab remount
+        // within a running circuit. So on first render always reconcile against localStorage and let
+        // it win, re-rendering only when it actually differs (no flash when it already matches).
+        if (firstRender && HasStateKey)
+        {
+            var json = await StateStore.GetStateAsync(StateKey!);
+            if (TryDeserialize(json, out var restored))
+            {
+                var before = SnapshotKey();
+                ApplyViewState(restored);
+                _stateRestored = true;
+                if (SnapshotKey() != before)
+                {
+                    // Bump a tracked version so ShouldRender() doesn't suppress this post-first-render
+                    // update (a single render re-emits both the pagination selector and sort indicators),
+                    // and re-key the Pagination so its page-size selector re-reads the restored value.
+                    _paginationVersion++;
+                    _stateRestoreKey++;
+                    await ProcessDataAsync();
+                    StateHasChanged();
+                }
+            }
+        }
+
         try
         {
             _dotNetRef ??= DotNetObjectReference.Create(this);
@@ -1964,6 +2144,8 @@ public partial class DataTable<TData> : ComponentBase, IAsyncDisposable where TD
 
     public async ValueTask DisposeAsync()
     {
+        _persistingSubscription.Dispose();
+
         if (_resizeCleanup is not null)
         {
             try { await _resizeCleanup.InvokeVoidAsync("dispose"); } catch { }

--- a/src/NeoUI.Blazor/Components/DataTable/DataTableViewState.cs
+++ b/src/NeoUI.Blazor/Components/DataTable/DataTableViewState.cs
@@ -1,0 +1,22 @@
+using NeoUI.Blazor.Primitives;
+
+namespace NeoUI.Blazor;
+
+/// <summary>
+/// Serializable snapshot of a <see cref="DataTable{TData}"/>'s user-adjustable view state.
+/// Persisted (and restored) per <c>StateKey</c> so paging and sort survive navigation.
+/// </summary>
+public sealed record DataTableViewState
+{
+    /// <summary>Rows-per-page selection.</summary>
+    public int PageSize { get; init; }
+
+    /// <summary>Current page (1-based).</summary>
+    public int CurrentPage { get; init; }
+
+    /// <summary>Id of the sorted column, or null when unsorted.</summary>
+    public string? SortedColumn { get; init; }
+
+    /// <summary>Active sort direction.</summary>
+    public SortDirection Direction { get; init; }
+}

--- a/src/NeoUI.Blazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/NeoUI.Blazor/Extensions/ServiceCollectionExtensions.cs
@@ -98,7 +98,10 @@ public static class ServiceCollectionExtensions
       
         // Register CollapsibleStateService for sidebar collapsible menu state persistence
         services.AddScoped<CollapsibleStateService>();
-        
+
+        // Register KeyedStateService for generic keyed state persistence (e.g. DataTable StateKey)
+        services.AddScoped<KeyedStateService>();
+
         // Register ThemeService for theme management
         services.AddScoped<ThemeService>();
 

--- a/src/NeoUI.Blazor/Services/KeyedStateService.cs
+++ b/src/NeoUI.Blazor/Services/KeyedStateService.cs
@@ -1,0 +1,131 @@
+using Microsoft.JSInterop;
+
+namespace NeoUI.Blazor.Services;
+
+/// <summary>
+/// Generic keyed state persistence service. Stores arbitrary string values (typically JSON) via a
+/// JavaScript module that writes both localStorage and cookies. The cookie copy lets components read
+/// saved state server-side during SSR pre-rendering (via <c>IHttpContextAccessor</c>) before falling
+/// back to these client-side methods. This is the string/JSON counterpart to
+/// <see cref="CollapsibleStateService"/> (which is boolean-only) and uses the <c>neoui:state:</c> prefix.
+/// </summary>
+public class KeyedStateService : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private const string StoragePrefix = "neoui:state:";
+
+    // In-memory mirror of the last value read/written this scope (per circuit in Server, per app in
+    // WASM). Lets components restore synchronously — before first render — on a remount within the
+    // same session, avoiding the flicker of an async localStorage read after the first paint.
+    private readonly Dictionary<string, string> _cache = new();
+
+    /// <summary>
+    /// Gets the storage key prefix used for keyed state storage. Used by components that read the
+    /// cookie fallback server-side.
+    /// </summary>
+    public static string KeyPrefix => StoragePrefix;
+
+    /// <summary>
+    /// Synchronously reads the value cached in memory for this scope (populated by prior
+    /// Get/Set calls). Returns false when nothing has been read or written for the key yet.
+    /// Use this to restore state before the first render (no JS interop, no flicker).
+    /// </summary>
+    public bool TryGetCached(string key, out string? value) => _cache.TryGetValue(key, out value);
+
+    private IJSObjectReference? _module;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeyedStateService"/> class.
+    /// </summary>
+    /// <param name="jsRuntime">The JavaScript runtime for interop operations.</param>
+    public KeyedStateService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async Task<IJSObjectReference> EnsureModuleAsync()
+    {
+        _module ??= await _jsRuntime.InvokeAsync<IJSObjectReference>(
+            "import", "./_content/NeoUI.Blazor/js/keyed-state.js");
+        return _module;
+    }
+
+    /// <summary>
+    /// Gets the saved value for a key from client-side storage (localStorage, then cookie).
+    /// Only available during client-side rendering (uses JS interop).
+    /// </summary>
+    /// <param name="key">Unique identifier for the state (without prefix).</param>
+    /// <returns>The saved string value, or <c>null</c> if none is stored.</returns>
+    public async Task<string?> GetStateAsync(string key)
+    {
+        try
+        {
+            var module = await EnsureModuleAsync();
+            var value = await module.InvokeAsync<string?>("getState", key);
+            if (value is not null)
+                _cache[key] = value;
+            return value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Saves a value for a key. Writes to both localStorage (client persistence) and a cookie (SSR).
+    /// </summary>
+    /// <param name="key">Unique identifier for the state (without prefix).</param>
+    /// <param name="value">The value to store (typically JSON).</param>
+    public async Task SetStateAsync(string key, string value)
+    {
+        _cache[key] = value;   // keep the sync cache current even if the JS write is delayed
+        try
+        {
+            var module = await EnsureModuleAsync();
+            await module.InvokeVoidAsync("setState", key, value);
+        }
+        catch
+        {
+            // Silently fail — persistence is best-effort.
+        }
+    }
+
+    /// <summary>
+    /// Clears the saved value for a key from both localStorage and cookie.
+    /// </summary>
+    /// <param name="key">Unique identifier for the state (without prefix).</param>
+    public async Task ClearStateAsync(string key)
+    {
+        _cache.Remove(key);
+        try
+        {
+            var module = await EnsureModuleAsync();
+            await module.InvokeVoidAsync("clearState", key);
+        }
+        catch
+        {
+            // Silently fail.
+        }
+    }
+
+    /// <summary>
+    /// Disposes the service and its JavaScript module.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            try
+            {
+                await _module.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+                // Circuit disconnected, ignore.
+            }
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/NeoUI.Blazor/wwwroot/js/keyed-state.js
+++ b/src/NeoUI.Blazor/wwwroot/js/keyed-state.js
@@ -1,0 +1,103 @@
+/**
+ * Generic keyed state management module.
+ * Persists arbitrary string values (typically JSON) in both localStorage and cookies,
+ * so state survives navigation and can be read server-side during SSR pre-rendering.
+ * Mirrors collapsible-state.js but stores raw strings instead of booleans.
+ */
+
+const STORAGE_PREFIX = "neoui:state:";
+const COOKIE_EXPIRATION_DAYS = 365;
+
+/**
+ * Get a saved value from localStorage (with cookie fallback).
+ * @param {string} key - The state key (without prefix)
+ * @returns {string|null} The saved value, or null if not found
+ */
+export function getState(key) {
+    const storageKey = STORAGE_PREFIX + key;
+
+    // Try localStorage first
+    const localValue = localStorage.getItem(storageKey);
+    if (localValue !== null) {
+        return localValue;
+    }
+
+    // Fallback to cookie (readable server-side during pre-render)
+    return getCookie(storageKey);
+}
+
+/**
+ * Save a value to both localStorage and a cookie.
+ * @param {string} key - The state key (without prefix)
+ * @param {string} value - The value to store (typically JSON)
+ */
+export function setState(key, value) {
+    const storageKey = STORAGE_PREFIX + key;
+
+    localStorage.setItem(storageKey, value);
+    setCookie(storageKey, value, COOKIE_EXPIRATION_DAYS);
+}
+
+/**
+ * Clear a saved value from both localStorage and cookie.
+ * @param {string} key - The state key (without prefix)
+ */
+export function clearState(key) {
+    const storageKey = STORAGE_PREFIX + key;
+
+    localStorage.removeItem(storageKey);
+    deleteCookie(storageKey);
+}
+
+/**
+ * Get cookie value.
+ * @param {string} name - Cookie name
+ * @returns {string|null} Cookie value or null
+ */
+function getCookie(name) {
+    // URL-encode the name to match how it was set
+    const encodedName = encodeURIComponent(name);
+    const nameEQ = encodedName + "=";
+    const ca = document.cookie.split(';');
+    for (let i = 0; i < ca.length; i++) {
+        let c = ca[i];
+        while (c.charAt(0) === ' ') c = c.substring(1, c.length);
+        if (c.indexOf(nameEQ) === 0) {
+            // URL-decode the value when returning
+            return decodeURIComponent(c.substring(nameEQ.length, c.length));
+        }
+    }
+    return null;
+}
+
+/**
+ * Set cookie value.
+ * @param {string} name - Cookie name
+ * @param {string} value - Cookie value
+ * @param {number} days - Expiration in days
+ */
+function setCookie(name, value, days) {
+    let expires = "";
+    if (days) {
+        const date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
+    }
+
+    // Add Secure flag for HTTPS so the cookie is sent to the server during pre-rendering
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+
+    // URL-encode the name and value to handle special characters like colons
+    const encodedName = encodeURIComponent(name);
+    const encodedValue = encodeURIComponent(value || "");
+
+    document.cookie = encodedName + "=" + encodedValue + expires + "; path=/; SameSite=Lax" + secure;
+}
+
+/**
+ * Delete cookie.
+ * @param {string} name - Cookie name
+ */
+function deleteCookie(name) {
+    setCookie(name, "", -1);
+}

--- a/src/NeoUI.Blazor/wwwroot/js/keyed-state.js
+++ b/src/NeoUI.Blazor/wwwroot/js/keyed-state.js
@@ -7,6 +7,10 @@
 
 const STORAGE_PREFIX = "neoui:state:";
 const COOKIE_EXPIRATION_DAYS = 365;
+// Stay well under the ~4KB per-cookie limit (leaving room for the name and attributes). Larger
+// values would be truncated by the browser — breaking the JSON — so we skip the cookie mirror for
+// them and rely on localStorage (only SSR pre-render restore is forgone in that case).
+const MAX_COOKIE_BYTES = 3800;
 
 /**
  * Get a saved value from localStorage (with cookie fallback).
@@ -16,10 +20,14 @@ const COOKIE_EXPIRATION_DAYS = 365;
 export function getState(key) {
     const storageKey = STORAGE_PREFIX + key;
 
-    // Try localStorage first
-    const localValue = localStorage.getItem(storageKey);
-    if (localValue !== null) {
-        return localValue;
+    // localStorage can throw in privacy / blocked-storage modes — fall back to the cookie.
+    try {
+        const localValue = localStorage.getItem(storageKey);
+        if (localValue !== null) {
+            return localValue;
+        }
+    } catch {
+        // fall through to the cookie
     }
 
     // Fallback to cookie (readable server-side during pre-render)
@@ -34,7 +42,13 @@ export function getState(key) {
 export function setState(key, value) {
     const storageKey = STORAGE_PREFIX + key;
 
-    localStorage.setItem(storageKey, value);
+    // Best-effort: a localStorage write can throw (quota exceeded / blocked storage); still mirror
+    // to the cookie so persistence keeps working.
+    try {
+        localStorage.setItem(storageKey, value);
+    } catch {
+        // ignore — the cookie mirror below is the fallback
+    }
     setCookie(storageKey, value, COOKIE_EXPIRATION_DAYS);
 }
 
@@ -45,7 +59,11 @@ export function setState(key, value) {
 export function clearState(key) {
     const storageKey = STORAGE_PREFIX + key;
 
-    localStorage.removeItem(storageKey);
+    try {
+        localStorage.removeItem(storageKey);
+    } catch {
+        // best-effort
+    }
     deleteCookie(storageKey);
 }
 
@@ -90,6 +108,14 @@ function setCookie(name, value, days) {
     // URL-encode the name and value to handle special characters like colons
     const encodedName = encodeURIComponent(name);
     const encodedValue = encodeURIComponent(value || "");
+
+    // Cookies are size-limited (~4KB) and sent on every request. Skip mirroring oversized values —
+    // the browser would truncate them (corrupting the JSON) — and drop any prior cookie so SSR never
+    // reads a stale/partial value. localStorage still holds the full value.
+    if (encodedName.length + encodedValue.length > MAX_COOKIE_BYTES) {
+        deleteCookie(name);
+        return;
+    }
 
     document.cookie = encodedName + "=" + encodedValue + expires + "; path=/; SameSite=Lax" + secure;
 }


### PR DESCRIPTION
## What
Adds an opt-in **`StateKey`** parameter to `DataTable`. When set, the table's view state — **page size, current page, and sort (column + direction)** — is persisted per key and restored across navigation, tab switches, and full reloads. Omit `StateKey` and behavior is unchanged.

Fixes the annoyance where changing rows-per-page (or sort) resets after navigating away and back.

## How
Reuses the repo's `StateKey` persistence standard (`SidebarCollapsibleGroup` / `CollapsibleStateService`):
- New generic **`KeyedStateService`** + **`keyed-state.js`** store strings/JSON in localStorage with a cookie mirror (prefix `neoui:state:`) so SSR pre-render can read state server-side.
- Layered restore:
  - **tier 0** — an in-memory cache on the (circuit/app-scoped) service, so a remount within the same session restores **synchronously in `OnInitialized` (before first render)** → no flicker;
  - **tier 1** — `PersistentComponentState` (SSR→interactive handover);
  - **tier 2** — cookie (server pre-render);
  - **async fallback** — localStorage in `OnAfterRenderAsync`, treated as authoritative (rewritten on every change) so a stale `PersistentComponentState` snapshot can't shadow the live value on a tab remount. On an async restore the `Pagination` is re-keyed so its page-size selector reflects the restored value.

## Demo
A **"State Persistence"** section on `/components/datatable` (keyed table + unkeyed control in `Tabs`), plus a `StateKey` API-table row.

## Verification (Playwright, interactive-server)
Page size **and** sort persist across tab round-trip and full reload; current page too; the unkeyed control resets; the selector shows the restored value; and the restore lands on the first render (no flicker — row samples go straight to the restored count).

## Scope
Components-only (nothing in primitives) → single `components` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)