### PR TITLE
fix(toast): register IToastService scoped, not singleton

### DIFF
--- a/src/NeoUI.Blazor/Extensions/ServiceCollectionExtensions.cs
+++ b/src/NeoUI.Blazor/Extensions/ServiceCollectionExtensions.cs
@@ -105,8 +105,12 @@ public static class ServiceCollectionExtensions
         // Register ThemeService for theme management
         services.AddScoped<ThemeService>();
 
-        // Register ToastService
-        services.AddSingleton<IToastService, ToastService>();
+        // Register ToastService. Scoped, NOT singleton: ToastService holds a mutable per-user toast list, so a
+        // singleton in Blazor Server shares ONE store across every circuit on the server — a toast shown from
+        // one circuit renders in all of them (e.g. a broadcast notification Toast.Show'd in each open tab
+        // duplicates across tabs). Scoped gives each circuit its own store; in WebAssembly (single app-wide
+        // scope) it behaves identically to the old singleton, so this is safe in both hosting models.
+        services.AddScoped<IToastService, ToastService>();
 
         return services;
     }


### PR DESCRIPTION
ToastService holds a mutable per-user toast list but was registered singleton. In Blazor Server a singleton shares one toast store across every circuit, so a toast shown from one circuit renders in all of them — a broadcast notification Toast.Show'd in each open tab duplicates across tabs. Scoped gives each circuit its own store (consistent with ThemeService/DialogService/etc., all already scoped). In WebAssembly the single app-wide scope makes scoped behave identically to the old singleton, so it's safe in both hosting models. Ships as components/v4.1.24.