### PR TITLE
fix(textarea): default UpdateOn to Change, not Input

### DIFF
--- a/src/NeoUI.Blazor/Components/Textarea/Textarea.razor.cs
+++ b/src/NeoUI.Blazor/Components/Textarea/Textarea.razor.cs
@@ -69,11 +69,24 @@ public partial class Textarea : ComponentBase, IAsyncDisposable
     /// Gets or sets when the input should update its bound value.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// - Input: Updates value immediately on every keystroke
     /// - Change: Updates value only when input loses focus (default)
+    /// </para>
+    /// <para>
+    /// Defaults to <see cref="InputUpdateMode.Change"/> so an interactive-server circuit is not
+    /// round-tripped on every keystroke — that latency is felt directly as laggy typing, and a
+    /// textarea is the control users type the most into. This also aligns Textarea with the other
+    /// text inputs (Input, NumericInput, MaskedInput, CurrencyInput), which already default to
+    /// Change; Textarea was the sole outlier despite this remark documenting Change as the default.
+    /// </para>
+    /// <para>
+    /// Set <c>UpdateOn="InputUpdateMode.Input"</c> where per-keystroke updates are genuinely needed
+    /// (live preview, character counter), ideally together with <see cref="DebounceDelay"/>.
+    /// </para>
     /// </remarks>
     [Parameter]
-    public InputUpdateMode UpdateOn { get; set; } = InputUpdateMode.Input;
+    public InputUpdateMode UpdateOn { get; set; } = InputUpdateMode.Change;
 
     /// <summary>
     /// Gets or sets the debounce delay in milliseconds for Input mode.
@@ -95,7 +108,8 @@ public partial class Textarea : ComponentBase, IAsyncDisposable
     /// Gets or sets the callback invoked when the textarea value changes.
     /// </summary>
     /// <remarks>
-    /// This event is fired on every keystroke (oninput event).
+    /// Fired according to <see cref="UpdateOn"/>: on blur by default (Change), or on every
+    /// keystroke when <see cref="UpdateOn"/> is set to Input.
     /// Use with Value parameter for two-way binding.
     /// </remarks>
     [Parameter]


### PR DESCRIPTION
fix(textarea): default UpdateOn to Change, not Input

Textarea was the only text input in the library defaulting to
InputUpdateMode.Input, so every keystroke invoked OnInputChanged over the
caller's circuit. On Blazor interactive-server that round-trip is felt
directly as laggy typing — and a textarea is the control users type the
most into (personas, notes, long-form copy).

Its own <remarks> already documented "Change: ... (default)", so the code
contradicted the docs. Input, NumericInput, MaskedInput and CurrencyInput
all default to Change; this makes Textarea consistent with them.

No JS change needed: initializeInput always attaches a change listener and
invokes OnInputChanged when updateOn='change' — the same path the other
inputs already use. Per-keystroke behaviour remains available opt-in via
UpdateOn="InputUpdateMode.Input" (ideally with DebounceDelay).

BEHAVIOUR CHANGE for consumers that relied on the old default: bound values
now update on blur rather than per keystroke. Live previews, character
counters and @bind-Value:after callbacks driven by a Textarea will fire on
blur unless they opt back in to Input.

Also corrects the ValueChanged remark, which claimed it fires on every
keystroke regardless of UpdateOn.
